### PR TITLE
fixes ProfilesLocation not being set on config

### DIFF
--- a/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
+++ b/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Extensions.Configuration
         internal const string LOG_GROUP = "LogGroup";
         internal const string REGION = "Region";
         internal const string PROFILE = "Profile";
+        internal const string PROFILES_LOCATION = "ProfilesLocation";
         internal const string BATCH_PUSH_INTERVAL = "BatchPushInterval";
         internal const string BATCH_PUSH_SIZE_IN_BYTES = "BatchPushSizeInBytes";
         internal const string LOG_LEVEL = "LogLevel";
@@ -52,6 +53,10 @@ namespace Microsoft.Extensions.Configuration
             if (loggerConfigSection[PROFILE] != null)
             {
                 Config.Profile = loggerConfigSection[PROFILE];
+            }
+            if (loggerConfigSection[PROFILES_LOCATION] != null)
+            {
+                Config.ProfilesLocation = loggerConfigSection[PROFILES_LOCATION];
             }
             if (loggerConfigSection[BATCH_PUSH_INTERVAL] != null)
             {


### PR DESCRIPTION
GetAWSLoggingConfigSection would return an object with no ProfilesLocation set, this now checks and adds ProfilesLocation as well from the config.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
